### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/automerge_dependencies.yml
+++ b/.github/workflows/automerge_dependencies.yml
@@ -3,6 +3,10 @@ name: auto-merge dependencies
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/iyaki/content-curator/security/code-scanning/5](https://github.com/iyaki/content-curator/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions used:
1. `actions/checkout@v4` requires `contents: read` to check out the repository's code.
2. `ahmadnassri/action-dependabot-auto-merge@v2` likely requires `pull-requests: write` to merge pull requests.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as this workflow has only one job (`auto-merge`). This ensures the `GITHUB_TOKEN` has the least privileges necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
